### PR TITLE
add ability to skip checking for hadoopJar

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ The 'runSpark' Gradle task takes two arguments '-PsparkMain' and '-PsparkArgs':
 
 Below are some sample commands for some simple demos:
 
-- SparkPi: ```gradle runSpark -PsparkMain="com.cloudera.sa.SparkPi" -PsparkArgs="local[2] 100"```
-- Sessionize: ```gradle runSpark -PsparkMain="com.cloudera.sa.Sessionize" -PsparkArgs="local[2]"```
-- HdfsWordCount: ```gradle runSpark -PsparkMain="com.cloudera.sa.HdfsWordCount" -PsparkArgs="local[2] streaming-input"```
-- NetworkWordCount: ```gradle runSpark -PsparkMain="com.cloudera.sa.NetworkWordCount" -PsparkArgs="local[2] localhost 9999"```
+- SparkPi: ```gradle runSpark -PsparkMain="com.cloudera.sa.SparkPi" -PskipHadoopJar -PsparkArgs="local[2] 100"```
+- Sessionize: ```gradle runSpark -PsparkMain="com.cloudera.sa.Sessionize" -PskipHadoopJar  -PsparkArgs="local[2]"```
+- HdfsWordCount: ```gradle runSpark -PsparkMain="com.cloudera.sa.HdfsWordCount" -PskipHadoopJar  -PsparkArgs="local[2] streaming-input"```
+- NetworkWordCount: ```gradle runSpark -PsparkMain="com.cloudera.sa.NetworkWordCount" -PskipHadoopJar  -PsparkArgs="local[2] localhost 9999"```
 
 >**Note:** 
 >   The remaining steps are only required for running demos in "pseudo-distributed" mode and on a cluster.

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ task wrapper(type: Wrapper) {
     gradleVersion = "2.1"
 }
 
+hadoopJar.onlyIf { !project.hasProperty('skipHadoopJar') }
 
 task runSpark(dependsOn: 'hadoopJar', type: JavaExec) {
     classpath = files(hadoopJar.archivePath, configurations.providedCompile)


### PR DESCRIPTION
Thanks for the examples!

Here's a possible solution for the apparently obscene time (3+ minutes here) it takes to check inputs to hadoop.jar - if you know of another solution that at least does some dependency checking that would be great too, but I'm far from a gradle master.

Incidentally, I'm hoping to try to add some Kotlin examples soon. If it works, I can keep these in a separate branch, unless you'd like me to pull request them as well?
